### PR TITLE
Implemented improvements after user feedback:

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-starter-parent</artifactId>
-        <version>1.0.1.RELEASE</version>
+        <version>1.0.3.BUILD-SNAPSHOT</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -192,9 +192,28 @@
     <!-- (you don't need this if you are using a .RELEASE version) -->
     <repositories>
         <repository>
+            <id>spring-snapshots</id>
+            <url>http://repo.spring.io/snapshot</url>
+            <snapshots><enabled>true</enabled></snapshots>
+        </repository>
+        <repository>
+            <id>spring-milestones</id>
+            <url>http://repo.spring.io/milestone</url>
+        </repository>
+        <repository>
             <id>Sonatype-public</id>
             <name>SnakeYAML repository</name>
             <url>http://oss.sonatype.org/content/groups/public/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spring-snapshots</id>
+            <url>http://repo.spring.io/snapshot</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <url>http://repo.spring.io/milestone</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/src/main/java/com/ft/login/LogoutController.java
+++ b/src/main/java/com/ft/login/LogoutController.java
@@ -1,0 +1,15 @@
+package com.ft.login;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Profile("web")
+@Controller
+public class LogoutController {
+
+    @RequestMapping("/logout")
+    public String logout() {
+        return "login/logout";
+    }
+}

--- a/src/main/java/com/ft/report/DueDatePredicateFactory.java
+++ b/src/main/java/com/ft/report/DueDatePredicateFactory.java
@@ -38,8 +38,7 @@ public class DueDatePredicateFactory {
 
     private Predicate<ReportTask> createSundayForMondayPredicate(LocalDate today) {
         String sunday = getNextDay(today, DayOfWeek.SUNDAY);
-        String monday = getNextDay(today, DayOfWeek.MONDAY);
-        return rt -> sunday.equals(rt.getDue_on()) || monday.equals(rt.getDue_on());
+        return rt -> sunday.equals(rt.getDue_on());
     }
 
     private Predicate<ReportTask> createTomorrowPredicate(LocalDate today) {

--- a/src/main/java/com/ft/report/ReportsController.java
+++ b/src/main/java/com/ft/report/ReportsController.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 @Profile("web")
 @Controller
-@RequestMapping("/reports")
+@RequestMapping("/")
 public class ReportsController {
 
     private static DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("dd/MM/yyyy");
@@ -88,8 +88,7 @@ public class ReportsController {
 
         if (preferredReportType == ReportType.SUNDAY_FOR_MONDAY) {
             LocalDate sunday = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
-            LocalDate monday = sunday.plusDays(1);
-            return sunday.format(dateFormat) + " - " + monday.format(dateFormat);
+            return sunday.format(dateFormat);
         }
         if (preferredReportType == ReportType.TOMORROW) {
             return today.plusDays(1).format(dateFormat);

--- a/src/main/java/com/ft/report/model/ImportantTag.java
+++ b/src/main/java/com/ft/report/model/ImportantTag.java
@@ -1,0 +1,22 @@
+package com.ft.report.model;
+
+
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum ImportantTag {
+    LEVEL_1("Level 1"), CONFERENCE("Conference");
+
+    @Getter
+    private final String value;
+
+    ImportantTag(String value) {
+        this.value = value;
+    }
+
+    public static List<ImportantTag> asList() {
+        return Arrays.asList(ImportantTag.values());
+    }
+}

--- a/src/main/java/com/ft/report/model/ReportTask.java
+++ b/src/main/java/com/ft/report/model/ReportTask.java
@@ -4,6 +4,7 @@ import com.ft.asanaapi.model.Tag;
 import lombok.Data;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 @Data
 public class ReportTask {
@@ -13,4 +14,14 @@ public class ReportTask {
     private boolean completed = false;
     private List<Tag> tags;
     private List<ReportTask> subtasks;
+
+    public ReportTask() {}
+
+    public boolean isImportant() {
+        if (tags == null || tags.isEmpty()) {
+            return false;
+        }
+        return Stream.of(ImportantTag.values()).map(ImportantTag::getValue)
+                .anyMatch(importantTag -> tags.stream().anyMatch(tag -> tag.getName().equals(importantTag)));
+    }
 }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -14,7 +14,7 @@ server:
 security:
   basic:
     enabled: false
-  ignored: /,/health,/favicon.ico,/index.html,/js/**,/css/**
+  ignored: /health,/logout,/favicon.ico,/index.html,/js/**,/css/**
   sessions: ALWAYS
 ---
 logging:

--- a/src/main/resources/static/css/report.css
+++ b/src/main/resources/static/css/report.css
@@ -105,3 +105,7 @@ body {
 .panel {
     background: white;
 }
+.task-important {
+    font-size: 18px;
+    border-style: solid;
+}

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en">
     <head>
         <link rel="stylesheet" media="all" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" />
 
@@ -9,7 +9,7 @@
     <div class="jumbotron">
         <h1>Asana Tools</h1>
         <p></p>
-        <p><a class="btn btn-primary btn-lg" href="/reports" role="button">Generate some reports!</a></p>
+        <p><a class="btn btn-primary btn-lg" href="/" role="button">Generate some reports!</a></p>
     </div>
         </div>
     </body>

--- a/src/main/resources/templates/login/logout.html
+++ b/src/main/resources/templates/login/logout.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<link rel="stylesheet" media="all" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css"/>
+<link rel="shortcut icon" href="http://im.ft-static.com/m/icons/favicon.ico" type="image/x-icon" />
+
+<!-- Origami imports -->
+<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-header@^3.0.6"/>
+<script src="//build.origami.ft.com/bundles/js?modules=o-header@^3.0.6"></script>
+
+<head>
+    <title>You are not authorized</title>
+</head>
+<body>
+<!-- FT Style Header - http://registry.origami.ft.com/components/o-header@3.0.6 -->
+<header data-o-component="o-header" class="o-header">
+    <div class="o-header__container">
+        <div class="o-header__inner">
+            <div class="o-header__primary">
+                <div class="o-header__primary__left">
+                    <div class="o-header__logo o-header__logo--ft">
+                        <a href="http://www.ft.com/">
+                            <abbr title="Financial Times">FT</abbr>
+                        </a>
+                        <a href="">
+                            <h1 class="o-header__title">Sorry, you are not authorized</h1>
+                        </a>
+                    </div>
+                </div>
+                <div class="o-header__primary__center"><h2 class="o-header__tagline">
+                    <!-- could add a secondary title here --></h2></div>
+            </div>
+        </div>
+    </div>
+</header>
+
+</body>
+</html>

--- a/src/main/resources/templates/reports/home.html
+++ b/src/main/resources/templates/reports/home.html
@@ -5,7 +5,7 @@
 <link rel="shortcut icon" href="http://im.ft-static.com/m/icons/favicon.ico" type="image/x-icon" />
 
 <!-- Origami imports -->
-<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-header@^3.0.6"/>
+<link rel="stylesheet" href="//build.origami.ft.com/bundles/css?modules=o-header@^3.0.6,o-ft-icons@^2.3.7"/>
 <script src="//build.origami.ft.com/bundles/js?modules=o-header@^3.0.6"></script>
 
 <head>
@@ -43,7 +43,7 @@
         <div class="panel-body">
 
             <form id="reportCriteriaForm" class="form-inline" action="#" method="post"
-                  th:action="@{/reports}"
+                  th:action="@{/}"
                   th:object="${criteria}">
 
                 <!-- Validation errors -->
@@ -108,7 +108,8 @@
                         <tr th:each="task: ${tt.value}">
                             <td>
                                 <div>
-                                    <b th:text="${task.name}"></b>
+                                    <span th:class="${task.important} ? 'o-ft-icons-icon o-ft-icons-icon--arrow-upwards'"></span>
+                                    <b th:text="${task.name}" ></b>
                                     <span th:unless="${#lists.isEmpty(task.tags)}"
                                           th:text="${#strings.listJoin(task.tags,', ')}"
                                           class="tags_sm">Secondary tags</span>

--- a/src/test/groovy/com/ft/report/DueDatePredicateFactorySpec.groovy
+++ b/src/test/groovy/com/ft/report/DueDatePredicateFactorySpec.groovy
@@ -17,7 +17,6 @@ class DueDatePredicateFactorySpec extends Specification {
     private static final LocalDate TODAY = LocalDate.of(2015, Month.JUNE, 11)
     private static final LocalDate TOMORROW = TODAY.plusDays(1)
     private static final LocalDate NEXT_SUNDAY = LocalDate.of(2015, Month.JUNE, 14)
-    private static final LocalDate NEXT_MONDAY = LocalDate.of(2015, Month.JUNE, 15)
     private static final LocalDate NEXT_TUESDAY = LocalDate.of(2015, Month.JUNE, 16)
 
     private static final ZoneId zoneId = ZoneId.systemDefault()
@@ -41,7 +40,6 @@ class DueDatePredicateFactorySpec extends Specification {
         where:
             reportType                   | dueDate
             ReportType.SUNDAY_FOR_MONDAY | NEXT_SUNDAY
-            ReportType.SUNDAY_FOR_MONDAY | NEXT_MONDAY
             ReportType.TODAY             | TODAY
             ReportType.TOMORROW          | TOMORROW
             null                         | null

--- a/src/test/groovy/com/ft/report/ReportGeneratorIntegrationSpec.groovy
+++ b/src/test/groovy/com/ft/report/ReportGeneratorIntegrationSpec.groovy
@@ -87,7 +87,7 @@ class ReportGeneratorIntegrationSpec extends IntegrationSpec {
         reportTask.name = "Finserv task 1"
         reportTask.notes = "some notes"
         reportTask.completed = false
-        reportTask.due_on = "2015-06-15"
+        reportTask.due_on = "2015-06-14"
         reportTask.subtasks = []
         reportTask.tags = [new Tag(id: 33751312101034, name: "Asia")]
         return reportTask
@@ -110,7 +110,7 @@ class ReportGeneratorIntegrationSpec extends IntegrationSpec {
         reportTask1.name = "Europe task 1"
         reportTask1.notes = "some notes"
         reportTask1.completed = false
-        reportTask1.due_on = "2015-06-15"
+        reportTask1.due_on = "2015-06-14"
         reportTask1.tags = [new Tag(id: '33751312101034', name: 'Asia')]
         reportTask1.subtasks = []
 
@@ -118,7 +118,7 @@ class ReportGeneratorIntegrationSpec extends IntegrationSpec {
         reportTask2.name = "Europe task 2"
         reportTask2.notes = "some notes"
         reportTask2.completed = false
-        reportTask2.due_on = "2015-06-15"
+        reportTask2.due_on = "2015-06-14"
         reportTask2.tags = []
         reportTask2.subtasks = []
 
@@ -130,7 +130,7 @@ class ReportGeneratorIntegrationSpec extends IntegrationSpec {
         reportTask2.name = "Other task 1"
         reportTask2.notes = "some notes"
         reportTask2.completed = false
-        reportTask2.due_on = "2015-06-15"
+        reportTask2.due_on = "2015-06-14"
         reportTask2.tags = [new Tag(id: '32896507462011', name: 'Unmapped tag')]
         reportTask2.subtasks = []
 

--- a/src/test/groovy/com/ft/report/ReportsControllerSpec.groovy
+++ b/src/test/groovy/com/ft/report/ReportsControllerSpec.groovy
@@ -66,7 +66,7 @@ class ReportsControllerSpec extends Specification {
             preferredReportType          | expectedReportDate
             ReportType.TODAY             | '01/06/2015'
             ReportType.TOMORROW          | '02/06/2015'
-            ReportType.SUNDAY_FOR_MONDAY | '07/06/2015 - 08/06/2015'
+            ReportType.SUNDAY_FOR_MONDAY | '07/06/2015'
     }
 
     @Unroll

--- a/src/test/groovy/com/ft/report/model/ReportTaskSpec.groovy
+++ b/src/test/groovy/com/ft/report/model/ReportTaskSpec.groovy
@@ -1,0 +1,27 @@
+package com.ft.report.model
+
+import com.ft.asanaapi.model.Tag
+import spock.lang.Specification
+
+class ReportTaskSpec extends Specification {
+
+    void "isImportant with no tags"() {
+        expect:
+            !new ReportTask().important
+    }
+
+    void "isImportant with not important tag"() {
+        given:
+            Tag tag = new Tag(name: 'dummy')
+        expect:
+            !new ReportTask(tags: [tag]).important
+    }
+
+    void "isImportant with important tag"() {
+        given:
+            ImportantTag importantTag = ImportantTag.asList().first()
+            Tag tag = new Tag(name: importantTag.value)
+        expect:
+            new ReportTask(tags: [tag]).important
+    }
+}

--- a/src/test/resources/__files/report/companies_sunday_4_monday.json
+++ b/src/test/resources/__files/report/companies_sunday_4_monday.json
@@ -25,7 +25,7 @@
       "name": "Finserv task 1",
       "notes": "some notes",
       "completed": false,
-      "due_on": "2015-06-15",
+      "due_on": "2015-06-14",
       "subtasks": [],
       "tags": [
         {
@@ -43,7 +43,7 @@
       "name": "Other task 1",
       "notes": "some notes",
       "completed": false,
-      "due_on": "2015-06-15",
+      "due_on": "2015-06-14",
       "subtasks": [],
       "tags": [
         {

--- a/src/test/resources/__files/report/world_sunday_4_monday.json
+++ b/src/test/resources/__files/report/world_sunday_4_monday.json
@@ -5,7 +5,7 @@
       "name": "Europe task 1",
       "notes": "some notes",
       "completed": false,
-      "due_on": "2015-06-15",
+      "due_on": "2015-06-14",
       "subtasks": [],
       "tags": [
         {
@@ -23,7 +23,7 @@
       "name": "Europe task 2",
       "notes": "some notes",
       "completed": false,
-      "due_on": "2015-06-15",
+      "due_on": "2015-06-14",
       "subtasks": [],
       "tags": [
         {


### PR DESCRIPTION
- reports are mapped to root "/"
- emphasized important tasks (tagged as Level 1 or Conference)
- Changed due date filtering for Sunday For Monday report to filter only on Sunday.
- Added logout endpoint for unauthorized users.
- brought back spring-cloud-security 1.0.3.SNAPSHOT version as 1.0.1.RELEASE didn't work with Google SSO.