### PR TITLE
Log the details of failing task when task runner fails

### DIFF
--- a/src/main/java/com/ft/config/TaskBot.java
+++ b/src/main/java/com/ft/config/TaskBot.java
@@ -5,11 +5,13 @@ import com.ft.asanaapi.AsanaClientWrapper;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Map;
 
 @Getter @Setter
 @NoArgsConstructor
+@ToString
 public class TaskBot {
     private String name;
     private String projectId;

--- a/src/main/java/com/ft/tasks/TaskDueDateTaskRunner.java
+++ b/src/main/java/com/ft/tasks/TaskDueDateTaskRunner.java
@@ -24,9 +24,8 @@ public class TaskDueDateTaskRunner implements TaskRunner {
     @Override
     public void run(final TaskBot taskBot) {
         AsanaClientWrapper client = taskBot.getClient();
-        String projectId = taskBot.getProjectId();
         try {
-            List<Task> tasks = client.getTasksByProject(projectId);
+            List<Task> tasks = client.getTasksByProject(taskBot.getProjectId());
             final String botName = taskBot.getName();
 
             tasks.stream().forEach(task -> {
@@ -42,7 +41,7 @@ public class TaskDueDateTaskRunner implements TaskRunner {
                         client.updateTask(task, taskData);
                         logger.info("{} bot successfully updated task: {} due date to {}.", botName, task.gid, taskDueDate);
                     } catch (IOException e) {
-                        logger.error("error updating task: {} in project: {}", task.name, projectId, e);
+                        logger.error("error updating task: {} in bot: {}", task.name, botName, e);
                     }
                 }
             });

--- a/src/main/java/com/ft/tasks/TaskDueDateTaskRunner.java
+++ b/src/main/java/com/ft/tasks/TaskDueDateTaskRunner.java
@@ -24,8 +24,9 @@ public class TaskDueDateTaskRunner implements TaskRunner {
     @Override
     public void run(final TaskBot taskBot) {
         AsanaClientWrapper client = taskBot.getClient();
+        String projectId = taskBot.getProjectId();
         try {
-            List<Task> tasks = client.getTasksByProject(taskBot.getProjectId());
+            List<Task> tasks = client.getTasksByProject(projectId);
             final String botName = taskBot.getName();
 
             tasks.stream().forEach(task -> {
@@ -41,12 +42,12 @@ public class TaskDueDateTaskRunner implements TaskRunner {
                         client.updateTask(task, taskData);
                         logger.info("{} bot successfully updated task: {} due date to {}.", botName, task.gid, taskDueDate);
                     } catch (IOException e) {
-                        logger.error("error updating task", e);
+                        logger.error("error updating task: {} in project: {}", task.name, projectId, e);
                     }
                 }
             });
         } catch (IOException e) {
-            logger.error("error updating task", e);
+            logger.error("error updating task {}", taskBot, e);
 
         }
 


### PR DESCRIPTION
We have been having a lot of errors in the log of late - [see splunk](https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3D%22heroku%22%20source%3D%22%2Fvar%2Flog%2Fapps%2Fheroku%2Fasana-bot.log%22%20%22com.asana.errors.ForbiddenError%22&display.page.search.mode=fast&dispatch.sample_ratio=1&workload_pool=standard_perf&earliest=-30d%40d&latest=now&sid=1625130115.16764300), but it is not possible to tell which of the bots is failing, this change logs out the bots detail so it is easy to investigate errors