### PR TITLE
exclude apiKey from taskBot toString

### DIFF
--- a/src/main/java/com/ft/config/TaskBot.java
+++ b/src/main/java/com/ft/config/TaskBot.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 @Getter @Setter
 @NoArgsConstructor
-@ToString
+@ToString(exclude = {"apiKey", "client"})
 public class TaskBot {
     private String name;
     private String projectId;


### PR DESCRIPTION
## Problem
Taskbot toString is logging the apiKey as well

## Solution
Exclude apiKey from toString